### PR TITLE
add show ignore file toggle doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ OSX 特别注意：
 
     space  # 折叠/展开代码
 
+    Shift-i  # 目录是否显示隐藏文件（NERDTree）。便于git开发，默认永远不显示.git。
+
+
 # 相关文档
 
 1. [Building-Vim-from-source](https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source)

--- a/vimrc
+++ b/vimrc
@@ -165,9 +165,9 @@ endif
 map <C-t> :NERDTreeToggle<CR>
 " NERDTree settings
 " 是否显示隐藏文件
-let NERDTreeShowHidden=1
+let NERDTreeShowHidden=0
 " 忽略一下文件的显示
-let NERDTreeIgnore=['\.pyc','\~$','\.swp','__pycache__']
+let NERDTreeIgnore=['\.pyc','\~$','\.swp','__pycache__','\.git$','\.DS_Store']
 " NERDTree git 扩展
 let g:NERDTreeIndicatorMapCustom = {
     \ "Modified"  : "✹",


### PR DESCRIPTION
默认忽略掉.git文件夹的显示（无论是否开启显示隐藏文件）。目的是在开发模式下，一般只会关心.gitignore或其他备份的配置文件。
