### PR TITLE
remove textwidth=79

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -168,8 +168,7 @@ au BufNewFile,BufRead *
 \ set list listchars=tab:>-
 
 au BufNewFile,BufRead *.py
-\ set colorcolumn=80 |
-\ set textwidth=79
+\ set colorcolumn=80
 
 au BufNewFile,BufRead *.go
 \ set nolist


### PR DESCRIPTION
实际使用中，自动换行带来的麻烦远远多于好处。绝大多时候根本不是所想要的效果。所以去掉了py中的自动换行。