### PR TITLE
update vimrc for colors

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -233,6 +233,7 @@ if has('gui_running')
 else
     colorscheme molokai
 endif
+set t_Co=256
 
 " 自定义代码折叠，折叠（和取消折叠）
 set foldmethod=syntax


### PR DESCRIPTION
在我的ubuntu16.04上配色基本失效， 修改vimrc，插入`set t_Co=256`后正常